### PR TITLE
Add link to LICENSE in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,10 @@ draft extensions first.
 
 ## Contributing
 
-The contributor understands that any contributions, if accepted by the OGC Membership and ISO/TC 211, shall be incorporated into
-OGC and ISO/TC 211 Web Feature Service standards documents and that all copyright and intellectual property shall be vested to the OGC.
+The contributor understands that any contributions, if accepted by the OGC Membership and ISO/TC 211, shall be incorporated into OGC and ISO/TC 211 Web Feature Service standards documents and that all copyright and intellectual property shall be vested to the OGC.
 
-The WFS/FES Standards Working Group (SWG) is the group at OGC responsible for the stewardship of the standard, but is
-working to do as much work in public as possible.
+The WFS/FES Standards Working Group (SWG) is the group at OGC responsible for the stewardship of the standard, but is working to do as much work in public as possible.
 
 * [Open issues](https://github.com/opengeospatial/WFS_FES/issues)
 * [Proposing changes](https://github.com/opengeospatial/WFS_FES/wiki/Propose-a-change-to-a-draft-of-a-WFS-specification-document)
+* [Copy of License Language](https://github.com/opengeospatial/WFS_FES/blob/master/LICENSE)


### PR DESCRIPTION
This isn't critical, but we might want to consider adding a link to the LICENSE language from the README file.