### PR TITLE
Change rel:item to rel:items

### DIFF
--- a/core/standard/clause_7_core.adoc
+++ b/core/standard/clause_7_core.adoc
@@ -459,7 +459,7 @@ geometries only in the default system (WGS84 longitude/latitude).
       },
       "links": [
         { "href": "http://data.example.org/collections/buildings/items",
-          "rel": "item", "type": "application/geo+json",
+          "rel": "items", "type": "application/geo+json",
           "title": "Buildings" },
         { "href": "http://example.org/concepts/building.html",
           "rel": "describedBy", "type": "text/html",

--- a/core/standard/clause_7_core.adoc
+++ b/core/standard/clause_7_core.adoc
@@ -427,7 +427,7 @@ NOTE: The `crs` property is not used by this conformance class, but reserved for
 =================
 This feature collection metadata example response in JSON is for a dataset with
 a single collection "buildings". It includes links to the collection resource in all formats that
-are supported by the service (link:https://www.iana.org/assignments/link-relations/link-relations.xhtml[link relation type]: "item").
+are supported by the service (link:https://www.iana.org/assignments/link-relations/link-relations.xhtml[link relation type]: "items").
 
 Representations of the metadata resource in other formats are referenced using link:https://www.iana.org/assignments/link-relations/link-relations.xhtml[link relation type] "alternate".
 

--- a/core/standard/requirements/core/REQ_fc-md-items-links.adoc
+++ b/core/standard/requirements/core/REQ_fc-md-items-links.adoc
@@ -5,7 +5,7 @@
 For each feature collection in this distribution of the dataset,
 the `links` property of the collection SHALL include
 an item for each supported encoding
-with a link to the collection resource (relation: `item`).
+with a link to the collection resource (relation: `items`).
 
 All links SHALL include the `rel` and `type` properties.
 |===

--- a/core/xml/examples/Collection.xml
+++ b/core/xml/examples/Collection.xml
@@ -9,11 +9,11 @@
    <Collection>
       <Name>roadl_1m</Name>
       <Title>Roads</Title>
-      <atom:link rel="item"
+      <atom:link rel="items"
             title="Roads"
             type="application/geo+json"
             href="http://www.acme.com/3.0/wfs/collections/roadl_1m/items?f=application%2Fvnd.geo%2Bjson"/>
-      <atom:link rel="item"
+      <atom:link rel="items"
             title="Roads"
             type="application/gml+xml;version=3.2;profile=http://www.opengis.net/def/profile/ogc/2.0/gml-sf0"
             href="http://www.acme.com/3.0/wfs/collections/roadl_1m/items?f=application%2Fgml%2Bxml%3Bversion%3D3.2%3Bprofile%3Dhttp%3A%2F%2Fwww.opengis.net%2Fdef%2Fprofile%2Fogc%2F2.0%2Fgml-sf0"/>

--- a/core/xml/examples/Collections.xml
+++ b/core/xml/examples/Collections.xml
@@ -25,11 +25,11 @@
    <Collection>
       <Name>aerofacp_1m</Name>
       <Title>Airport Facilities Points</Title>
-      <atom:link rel="item"
+      <atom:link rel="items"
             title="Airport Facilities Points"
             type="application/geo+json"
             href="http://www.acme.com/3.0/wfs/collections/aerofacp_1m/items?f=application%2Fvnd.geo%2Bjson"/>
-      <atom:link rel="item"
+      <atom:link rel="items"
             title="Airport Facilities Points"
             type="application/gml+xml;version=3.2;profile=http://www.opengis.net/def/profile/ogc/2.0/gml-sf0"
             href="http://www.acme.com/3.0/wfs/collections/aerofacp_1m/items?f=application%2Fgml%2Bxml%3Bversion%3D3.2%3Bprofile%3Dhttp%3A%2F%2Fwww.opengis.net%2Fdef%2Fprofile%2Fogc%2F2.0%2Fgml-sf0"/>
@@ -56,11 +56,11 @@
    <Collection>
       <Name>roadl_1m</Name>
       <Title>Roads</Title>
-      <atom:link rel="item"
+      <atom:link rel="items"
             title="Roads"
             type="application/geo+json"
             href="http://www.acme.com/3.0/wfs/collections/roadl_1m/items?f=application%2Fvnd.geo%2Bjson"/>
-      <atom:link rel="item"
+      <atom:link rel="items"
             title="Roads"
             type="application/gml+xml;version=3.2;profile=http://www.opengis.net/def/profile/ogc/2.0/gml-sf0"
             href="http://www.acme.com/3.0/wfs/collections/roadl_1m/items?f=application%2Fgml%2Bxml%3Bversion%3D3.2%3Bprofile%3Dhttp%3A%2F%2Fwww.opengis.net%2Fdef%2Fprofile%2Fogc%2F2.0%2Fgml-sf0"/>
@@ -87,11 +87,11 @@
    <Collection>
       <Name>inwatera_1m</Name>
       <Title>Inland Water Areas</Title>
-      <atom:link rel="item"
+      <atom:link rel="items"
             title="Inland Water Areas"
             type="application/geo+json"
             href="http://www.acme.com/3.0/wfs/collections/inwatera_1m/items?f=application%2Fvnd.geo%2Bjson"/>
-      <atom:link rel="item"
+      <atom:link rel="items"
             title="Inland Water Areas"
             type="application/gml+xml;version=3.2;profile=http://www.opengis.net/def/profile/ogc/2.0/gml-sf0"
             href="http://www.acme.com/3.0/wfs/collections/inwatera_1m/items?f=application%2Fgml%2Bxml%3Bversion%3D3.2%3Bprofile%3Dhttp%3A%2F%2Fwww.opengis.net%2Fdef%2Fprofile%2Fogc%2F2.0%2Fgml-sf0"/>

--- a/extensions/crs/clause_06_crs.adoc
+++ b/extensions/crs/clause_06_crs.adoc
@@ -40,7 +40,7 @@ This examples illustrates a list of supported coordinate reference systems.
       "description": "Buildings in the city of Bonn.",
       "links": [
         { "href": "http://data.example.org/collections/buildings/items",
-          "rel": "item", "type": "application/geo+json",
+          "rel": "items", "type": "application/geo+json",
           "title": "Buildings" },
         { "href": "http://example.org/concepts/building.html",
           "rel": "describedBy", "type": "text/html",
@@ -146,7 +146,7 @@ NOTE: Need to do more work on HTML!
 
 HTML only supports WGS84 based on schema.org dependency; not sure if this is
 an issue but schema.org annotations seem to require WGS84 (lat,lon) yet WFS
-core requires lon,lat by default. 
+core requires lon,lat by default.
 
 ==== Compatibility of coordinate reference systems (TBD)
 

--- a/guide/conformance_checklist.md
+++ b/guide/conformance_checklist.md
@@ -56,7 +56,7 @@ Derived from the [WFS 3.0, Part 1, version 3.0.0-draft.1](https://cdn.rawgit.com
   * [ ] rel "alternate" for each additional encoding available
   * [ ] (recommended) For each external link defining structure or semantics of data contained in collections, include a link w/ rel "describedBy"
 * [ ] Response "collections" property includes an entry for each feature collection.
-  * [ ] For each supported encoding include a link w/ rel "item" to the feature collection
+  * [ ] For each supported encoding include a link w/ rel "items" to the feature collection
   * [ ] If response provides an "extent" property it is formatted as a bounding box of the form [SWlong, SWlat, NElong, NElat] for the spatial and [begin, end] for the temporal extent
 * [ ] All links include "rel"
 * [ ] All links include "type" specifying content type

--- a/guide/section_11_conformance_checklists.adoc
+++ b/guide/section_11_conformance_checklists.adoc
@@ -58,7 +58,7 @@ Derived from the [WFS 3.0, Part 1, version 3.0.0-draft.1](https://cdn.rawgit.com
   * [ ] rel "alternate" for each additional encoding available
   * [ ] (recommended) For each external link defining structure or semantics of data contained in collections, include a link w/ rel "describedBy"
 * [ ] Response "collections" property includes an entry for each feature collection.
-  * [ ] For each supported encoding include a link w/ rel "item" to the feature collection
+  * [ ] For each supported encoding include a link w/ rel "items" to the feature collection
   * [ ] If response provides an "extent" property it is formatted as a bounding box of the form [SWlong, SWlat, NElong, NElat] for the spatial and [begin, end] for the temporal extent
 * [ ] All links include "rel"
 * [ ] All links include "type" specifying content type
@@ -95,4 +95,3 @@ Derived from the [WFS 3.0, Part 1, version 3.0.0-draft.1](https://cdn.rawgit.com
   * [ ] rel "self"
   * [ ] rel "alternate" for other content types supported.
   * [ ] rel "collection"
-

--- a/guide/section_11_conformance_checklists.html
+++ b/guide/section_11_conformance_checklists.html
@@ -501,7 +501,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
   * [ ] rel "alternate" for each additional encoding available
   * [ ] (recommended) For each external link defining structure or semantics of data contained in collections, include a link w/ rel "describedBy"
 * [ ] Response "collections" property includes an entry for each feature collection.
-  * [ ] For each supported encoding include a link w/ rel "item" to the feature collection
+  * [ ] For each supported encoding include a link w/ rel "items" to the feature collection
   * [ ] If response provides an "extent" property it is formatted as a bounding box of the form [SWlong, SWlat, NElong, NElat] for the spatial and [begin, end] for the temporal extent
 * [ ] All links include "rel"
 * [ ] All links include "type" specifying content type</p>


### PR DESCRIPTION
The rel link here links to the /items endpoint, but has a 'rel' of 'items'. In [STAC](https://github.com/radiantearth/stac-spec/) we extensively use rel=item to link to a specific item in our catalog. We are trying hard for WFS compatibility, and if this changes to 'items' instead of 'item' then we can be very compatible. We'd make use of rel=items to link to the wfs queryable endpoint, and rel=item to indicate a catalog link to a single item.

This was the only reference I found to this - not sure if it's even truly specified. It may be good to have some recommendations in or near the spec on the rel types that are used, and what they are used for.