### PR TITLE
Avoid XML syntax for HTML

### DIFF
--- a/core/standard/requirements/html/REQ_content.adoc
+++ b/core/standard/requirements/html/REQ_content.adoc
@@ -8,6 +8,6 @@ information in the HTML body:
 
 * all information identified in the schemas of the
 link:https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#responseObject[Response Object]
-in the HTML `<body/>`, and
-* all links in HTML `<a/>` elements in the HTML `<body/>`.
+in the HTML `<body>`, and
+* all links in HTML `<a>` elements in the HTML `<body>`.
 |===


### PR DESCRIPTION
While there is an obscure XML syntax for HTML 5, in "normal" HTML 5, one always has to write `<body></body>` and `<a></a>`.

The [HTML 5 spec](https://www.w3.org/TR/html52/single-page.html) consistently uses the terminology `<body>` element and `<a>` element, so I suggest to do the same here.